### PR TITLE
Added a new line after an error occurs

### DIFF
--- a/drive.go
+++ b/drive.go
@@ -144,5 +144,6 @@ func main() {
 
 func writeError(format string, err error) {
 	fmt.Fprintf(os.Stderr, format, err)
+	fmt.Print("\n")
 	os.Exit(1)
 }


### PR DESCRIPTION
Previously:
gdrive download -i {ID}
An error occurred: File is not **downloadable[keramidas@hostname gdrive]$**

Now:
gdrive download -i {ID}
**An error occurred: File is not downloadable**
**[keramidas@hostname gdrive]$**
