### PR TITLE
Add option to export google docs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -118,8 +118,6 @@ func printInfo(d *gdrive.Drive, f *drive.File) {
 		"Md5sum":      f.Md5Checksum,
 		"Shared":      util.FormatBool(isShared(d, f.Id)),
 		"Parents":     util.ParentList(f.Parents),
-		"Download":    f.DownloadUrl,
-		"Export":      f.ExportLinks["text/csv"],
 	}
 
 	order := []string{
@@ -133,8 +131,6 @@ func printInfo(d *gdrive.Drive, f *drive.File) {
 		"Md5sum",
 		"Shared",
 		"Parents",
-		"Download",
-		"Export",
 	}
 	util.Print(fields, order)
 }

--- a/drive.go
+++ b/drive.go
@@ -53,7 +53,9 @@ type Options struct {
 
 	Download struct {
 		FileId string `goptions:"-i, --id, mutexgroup='download', obligatory, description='File Id'"`
+		Export string `goptions:"-e, --export, description='Export file format for google docs'"`
 		Stdout bool   `goptions:"-s, --stdout, description='Write file content to stdout'"`
+		Force  bool   `goptions:"--force, description='Overwrite existing file'"`
 		Pop    bool   `goptions:"--pop, mutexgroup='download', description='Download latest file, and remove it from google drive'"`
 	} `goptions:"download"`
 
@@ -121,9 +123,9 @@ func main() {
 	case "download":
 		args := opts.Download
 		if args.Pop {
-			err = cli.DownloadLatest(drive, args.Stdout)
+			err = cli.DownloadLatest(drive, args.Stdout, args.Export, args.Force)
 		} else {
-			err = cli.Download(drive, args.FileId, args.Stdout, false)
+			err = cli.Download(drive, args.FileId, args.Stdout, false, args.Export, args.Force)
 		}
 
 	case "delete":

--- a/util/drive.go
+++ b/util/drive.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"github.com/prasmussen/google-api-go-client/drive/v2"
 	"fmt"
+	"github.com/prasmussen/google-api-go-client/drive/v2"
 	"strings"
 )
 
@@ -23,4 +23,46 @@ func ParentList(parents []*drive.ParentReference) string {
 	}
 
 	return strings.Join(ids, ", ")
+}
+
+func ExportFormat(info *drive.File, format string) (downloadUrl string, extension string, err error) {
+	// See https://developers.google.com/drive/web/manage-downloads#downloading_google_documents
+	switch format {
+	case "docx":
+		extension = ".docx"
+		downloadUrl = info.ExportLinks["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]
+	case "xlsx":
+		extension = ".xlsx"
+		downloadUrl = info.ExportLinks["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"]
+	case "pptx":
+		extension = ".pptx"
+		downloadUrl = info.ExportLinks["application/application/vnd.openxmlformats-officedocument.presentationml.presentation"]
+	case "odf":
+		extension = ".odf"
+		downloadUrl = info.ExportLinks["application/vnd.oasis.opendocument.text"]
+	case "ods":
+		extension = ".ods"
+		downloadUrl = info.ExportLinks["application/x-vnd.oasis.opendocument.spreadsheet"]
+	case "pdf":
+		extension = ".pdf"
+		downloadUrl = info.ExportLinks["application/pdf"]
+	case "rtf":
+		extension = ".rtf"
+		downloadUrl = info.ExportLinks["application/rtf"]
+	case "csv":
+		extension = ".csv"
+		downloadUrl = info.ExportLinks["text/csv"]
+	case "html":
+		extension = ".html"
+		downloadUrl = info.ExportLinks["text/html"]
+	case "txt":
+		extension = ".txt"
+		downloadUrl = info.ExportLinks["text/plain"]
+	case "json":
+		extension = ".json"
+		downloadUrl = info.ExportLinks["application/vnd.google-apps.script+json"]
+	default:
+		err = fmt.Errorf("Unknown export format: %s. Known formats: docx, xlsx, pptx, odf, ods, pdf, rtf, csv, txt, html, json", format)
+	}
+	return
 }


### PR DESCRIPTION
Since the googlecl tool is no longer working and nothing sensible seems to be around I have added the option to export google docs documents. They can be exported with the ExportLink download url.

The extra options are:
-e <format> 
--force to overwrite existing files

Hope you find this useful and others as well. Please let me know if you have any questions.