### PR TITLE
Where appropriate retrieves multiple pages when listing files

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -34,9 +34,20 @@ func List(d *gdrive.Drive, query, titleFilter string, maxResults int, sharedStat
 		return err
 	}
 
+	files := list.Items
+
+	for(list.NextPageToken != "") {
+		caller.PageToken(list.NextPageToken)
+		list, err = caller.Do()
+		if err != nil {
+			return err
+		}
+		files = append(files,list.Items...)
+	}
+
 	items := make([]map[string]string, 0, 0)
 
-	for _, f := range list.Items {
+	for _, f := range files {
 		if f.DownloadUrl == "" && !includeDocs {
 			if f.MimeType != "application/vnd.google-apps.folder" {
 				continue


### PR DESCRIPTION
Fixes this issue: https://github.com/prasmussen/gdrive/issues/38 whereby using the list verb returns a maximum of 460 results because the original implementation does not take account of having to iterate through multiple pages.