### PR TITLE
Make `go get` work

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ You will be prompted for a new verification code if the folder does not exist.
 
 ## Compile from source
 ```bash
-git clone https://github.com/prasmussen/gdrive.git
-cd gdrive
-go get ./...
-go build -o gdrive
+go get github.com/prasmussen/gdrive
 ```
 
 ## Gdrive 2

--- a/compare.go
+++ b/compare.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./drive"
+	"github.com/prasmussen/gdrive/drive"
 	"encoding/json"
 	"os"
 )

--- a/gdrive.go
+++ b/gdrive.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./cli"
+	"github.com/prasmussen/gdrive/cli"
 	"fmt"
 	"os"
 )

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"./auth"
-	"./cli"
-	"./drive"
+	"github.com/prasmussen/gdrive/auth"
+	"github.com/prasmussen/gdrive/cli"
+	"github.com/prasmussen/gdrive/drive"
 	"fmt"
 	"io"
 	"io/ioutil"

--- a/handlers_meta.go
+++ b/handlers_meta.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./cli"
+	"github.com/prasmussen/gdrive/cli"
 	"fmt"
 	"os"
 	"runtime"


### PR DESCRIPTION
`go get github.com/prasmussen/gdrive` fails with many
"Local import './auth' in non local package" (and others)

[After some research](https://stackoverflow.com/questions/30885098/go-local-import-in-non-local-package) it seems the preferred way to do local import is fully qualifying the name
etc. "github.com/prasmussen/gdrive/auth"

This lets you install the entire package with just `go get github.com/prasmussen/gdrive`
I changed the README to reflect that


