### PR TITLE
Clarifies the phrase 'first time gdrive is launched'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ If you want to compile from source you need the [go toolchain](http://golang.org
 ## Installation
 Download `gdrive` from one of the links below. On unix systems
 run `chmod +x gdrive` after download to make the binary executable.
-The first time gdrive is launched, you will be prompted for a verification code.
+The first time gdrive is launched (i.e. run `gdrive about` in your
+terminal not just `gdrive`), you will be prompted for a verification code.
 The code is obtained by following the printed url and authenticating with the
 google account for the drive you want access to. This will create a token file
 inside the .gdrive folder in your home directory. Note that anyone with access


### PR DESCRIPTION
Newbie users, like myself, compiled several versions of gdrive because we were not getting the auth. url when running `gdrive` from terminal as pointed out by the phrase "The first time gdrive is launched ... you will be prompted for a verification code".