### PR TITLE
add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you want to compile from source you need the [go toolchain](http://golang.org
 Version 1.5 or higher.
 
 ## Installation
+### [Homebrew](http://brew.sh) on Mac
+```
+brew tap paulz/gdrive
+brew install gdrive
+```
+### Other
 Download `gdrive` from one of the links below. On unix systems
 run `chmod +x gdrive` after download to make the binary executable.
 The first time gdrive is launched (i.e. run `gdrive about` in your

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ If you want to compile from source you need the [go toolchain](http://golang.org
 Version 1.5 or higher.
 
 ## Installation
-### [Homebrew](http://brew.sh) on Mac
+### With [Homebrew](http://brew.sh) on Mac
 ```
-brew tap paulz/gdrive
 brew install gdrive
 ```
 ### Other


### PR DESCRIPTION
Enables use of Homebrew package manager for mac users.
`brew tap paulz/gdrive` is a temporary step while official formula is being approved: https://github.com/Homebrew/homebrew-core/pull/754
