### PR TITLE
fix bad substitution error

### DIFF
--- a/_release/build-all.sh
+++ b/_release/build-all.sh
@@ -13,7 +13,7 @@ rm $BIN_PATH/* 2> /dev/null
 for PLATFORM in $PLATFORMS; do
     GOOS=${PLATFORM%/*}
     GOARCH=${PLATFORM#*/}
-    BIN_NAME="${APP_NAME}-${GOOS/darwin/osx}-${GOARCH/amd64/x64}"
+    BIN_NAME="${APP_NAME}-${GOOS}/darwin/osx-${GOARCH}/amd64/x64}"
 
     if [ $GOOS == "windows" ]; then
         BIN_NAME="${BIN_NAME}.exe"


### PR DESCRIPTION
An error was being triggered `build-all.sh: 16: build-all.sh: Bad substitution` when running the script.