### PR TITLE
Added --description option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,15 +195,16 @@ global:
   --access-token <accessToken>     Oauth access token, only recommended for short-lived requests because of short lifetime (for advanced users)
 
 options:
-  -r, --recursive           Upload directory recursively
-  -p, --parent <parent>     Parent id, used to upload file to a specific directory, can be specified multiple times to give many parents
-  --name <name>             Filename
-  --no-progress             Hide progress
-  --mime <mime>             Force mime type
-  --share                   Share file
-  --delete                  Delete local file when upload is successful
-  --timeout <timeout>       Set timeout in seconds, use 0 for no timeout. Timeout is reached when no data is transferred in set amount of seconds, default: 300
-  --chunksize <chunksize>   Set chunk size in bytes, default: 8388608
+  -r, --recursive               Upload directory recursively
+  -p, --parent <parent>         Parent id, used to upload file to a specific directory, can be specified multiple times to give many parents
+  --name <name>                 Filename
+  --description <description>   File description
+  --no-progress                 Hide progress
+  --mime <mime>                 Force mime type
+  --share                       Share file
+  --delete                      Delete local file when upload is successful
+  --timeout <timeout>           Set timeout in seconds, use 0 for no timeout. Timeout is reached when no data is transferred in set amount of seconds, default: 300
+  --chunksize <chunksize>       Set chunk size in bytes, default: 8388608
 ```
 
 #### Upload file from stdin
@@ -216,12 +217,13 @@ global:
   --access-token <accessToken>     Oauth access token, only recommended for short-lived requests because of short lifetime (for advanced users)
 
 options:
-  -p, --parent <parent>     Parent id, used to upload file to a specific directory, can be specified multiple times to give many parents
-  --chunksize <chunksize>   Set chunk size in bytes, default: 8388608
-  --mime <mime>             Force mime type
-  --share                   Share file
-  --timeout <timeout>       Set timeout in seconds, use 0 for no timeout. Timeout is reached when no data is transferred in set amount of seconds, default: 300
-  --no-progress             Hide progress
+  -p, --parent <parent>         Parent id, used to upload file to a specific directory, can be specified multiple times to give many parents
+  --chunksize <chunksize>       Set chunk size in bytes, default: 8388608
+  --description <description>   File description
+  --mime <mime>                 Force mime type
+  --share                       Share file
+  --timeout <timeout>           Set timeout in seconds, use 0 for no timeout. Timeout is reached when no data is transferred in set amount of seconds, default: 300
+  --no-progress                 Hide progress
 ```
 
 #### Update file, this creates a new revision of the file
@@ -234,12 +236,13 @@ global:
   --access-token <accessToken>     Oauth access token, only recommended for short-lived requests because of short lifetime (for advanced users)
 
 options:
-  -p, --parent <parent>     Parent id, used to upload file to a specific directory, can be specified multiple times to give many parents
-  --name <name>             Filename
-  --no-progress             Hide progress
-  --mime <mime>             Force mime type
-  --timeout <timeout>       Set timeout in seconds, use 0 for no timeout. Timeout is reached when no data is transferred in set amount of seconds, default: 300
-  --chunksize <chunksize>   Set chunk size in bytes, default: 8388608
+  -p, --parent <parent>         Parent id, used to upload file to a specific directory, can be specified multiple times to give many parents
+  --name <name>                 Filename
+  --description <description>   File description
+  --no-progress                 Hide progress
+  --mime <mime>                 Force mime type
+  --timeout <timeout>           Set timeout in seconds, use 0 for no timeout. Timeout is reached when no data is transferred in set amount of seconds, default: 300
+  --chunksize <chunksize>       Set chunk size in bytes, default: 8388608
 ```
 
 #### Show file info
@@ -265,7 +268,8 @@ global:
   --access-token <accessToken>     Oauth access token, only recommended for short-lived requests because of short lifetime (for advanced users)
 
 options:
-  -p, --parent <parent>   Parent id of created directory, can be specified multiple times to give many parents
+  -p, --parent <parent>         Parent id of created directory, can be specified multiple times to give many parents
+  --description <description>   Directory description
 ```
 
 #### Share file or directory

--- a/drive/mkdir.go
+++ b/drive/mkdir.go
@@ -9,9 +9,10 @@ import (
 const DirectoryMimeType = "application/vnd.google-apps.folder"
 
 type MkdirArgs struct {
-	Out     io.Writer
-	Name    string
-	Parents []string
+	Out         io.Writer
+	Name        string
+	Description string
+	Parents     []string
 }
 
 func (self *Drive) Mkdir(args MkdirArgs) error {
@@ -24,7 +25,11 @@ func (self *Drive) Mkdir(args MkdirArgs) error {
 }
 
 func (self *Drive) mkdir(args MkdirArgs) (*drive.File, error) {
-	dstFile := &drive.File{Name: args.Name, MimeType: DirectoryMimeType}
+	dstFile := &drive.File{
+		Name:        args.Name,
+		Description: args.Description,
+		MimeType:    DirectoryMimeType,
+	}
 
 	// Set parent folders
 	dstFile.Parents = args.Parents

--- a/drive/update.go
+++ b/drive/update.go
@@ -11,16 +11,17 @@ import (
 )
 
 type UpdateArgs struct {
-	Out       io.Writer
-	Progress  io.Writer
-	Id        string
-	Path      string
-	Name      string
-	Parents   []string
-	Mime      string
-	Recursive bool
-	ChunkSize int64
-	Timeout   time.Duration
+	Out         io.Writer
+	Progress    io.Writer
+	Id          string
+	Path        string
+	Name        string
+	Description string
+	Parents     []string
+	Mime        string
+	Recursive   bool
+	ChunkSize   int64
+	Timeout     time.Duration
 }
 
 func (self *Drive) Update(args UpdateArgs) error {
@@ -32,7 +33,7 @@ func (self *Drive) Update(args UpdateArgs) error {
 	defer srcFile.Close()
 
 	// Instantiate empty drive file
-	dstFile := &drive.File{}
+	dstFile := &drive.File{Description: args.Description}
 
 	// Use provided file name or use filename
 	if args.Name == "" {

--- a/drive/upload.go
+++ b/drive/upload.go
@@ -12,17 +12,18 @@ import (
 )
 
 type UploadArgs struct {
-	Out       io.Writer
-	Progress  io.Writer
-	Path      string
-	Name      string
-	Parents   []string
-	Mime      string
-	Recursive bool
-	Share     bool
-	Delete    bool
-	ChunkSize int64
-	Timeout   time.Duration
+	Out         io.Writer
+	Progress    io.Writer
+	Path        string
+	Name        string
+	Description string
+	Parents     []string
+	Mime        string
+	Recursive   bool
+	Share       bool
+	Delete      bool
+	ChunkSize   int64
+	Timeout     time.Duration
 }
 
 func (self *Drive) Upload(args UploadArgs) error {
@@ -110,9 +111,10 @@ func (self *Drive) uploadDirectory(args UploadArgs) error {
 	fmt.Fprintf(args.Out, "Creating directory %s\n", srcFileInfo.Name())
 	// Make directory on drive
 	f, err := self.mkdir(MkdirArgs{
-		Out:     args.Out,
-		Name:    srcFileInfo.Name(),
-		Parents: args.Parents,
+		Out:         args.Out,
+		Name:        srcFileInfo.Name(),
+		Parents:     args.Parents,
+		Description: args.Description,
 	})
 	if err != nil {
 		return err
@@ -129,6 +131,7 @@ func (self *Drive) uploadDirectory(args UploadArgs) error {
 		newArgs := args
 		newArgs.Path = filepath.Join(args.Path, name)
 		newArgs.Parents = []string{f.Id}
+		newArgs.Description = ""
 
 		// Upload
 		err = self.uploadRecursive(newArgs)
@@ -150,7 +153,7 @@ func (self *Drive) uploadFile(args UploadArgs) (*drive.File, int64, error) {
 	defer srcFile.Close()
 
 	// Instantiate empty drive file
-	dstFile := &drive.File{}
+	dstFile := &drive.File{Description: args.Description}
 
 	// Use provided file name or use filename
 	if args.Name == "" {
@@ -196,15 +199,16 @@ func (self *Drive) uploadFile(args UploadArgs) (*drive.File, int64, error) {
 }
 
 type UploadStreamArgs struct {
-	Out       io.Writer
-	In        io.Reader
-	Name      string
-	Parents   []string
-	Mime      string
-	Share     bool
-	ChunkSize int64
-	Progress  io.Writer
-	Timeout   time.Duration
+	Out         io.Writer
+	In          io.Reader
+	Name        string
+	Description string
+	Parents     []string
+	Mime        string
+	Share       bool
+	ChunkSize   int64
+	Progress    io.Writer
+	Timeout     time.Duration
 }
 
 func (self *Drive) UploadStream(args UploadStreamArgs) error {
@@ -213,7 +217,7 @@ func (self *Drive) UploadStream(args UploadStreamArgs) error {
 	}
 
 	// Instantiate empty drive file
-	dstFile := &drive.File{Name: args.Name}
+	dstFile := &drive.File{Name: args.Name, Description: args.Description}
 
 	// Set mime type if provided
 	if args.Mime != "" {

--- a/gdrive.go
+++ b/gdrive.go
@@ -213,6 +213,11 @@ func main() {
 						Patterns:    []string{"--name"},
 						Description: "Filename",
 					},
+					cli.StringFlag{
+						Name:        "description",
+						Patterns:    []string{"--description"},
+						Description: "File description",
+					},
 					cli.BoolFlag{
 						Name:        "noProgress",
 						Patterns:    []string{"--no-progress"},
@@ -270,6 +275,11 @@ func main() {
 						DefaultValue: DefaultUploadChunkSize,
 					},
 					cli.StringFlag{
+						Name:        "description",
+						Patterns:    []string{"--description"},
+						Description: "File description",
+					},
+					cli.StringFlag{
 						Name:        "mime",
 						Patterns:    []string{"--mime"},
 						Description: "Force mime type",
@@ -311,6 +321,11 @@ func main() {
 						Name:        "name",
 						Patterns:    []string{"--name"},
 						Description: "Filename",
+					},
+					cli.StringFlag{
+						Name:        "description",
+						Patterns:    []string{"--description"},
+						Description: "File description",
 					},
 					cli.BoolFlag{
 						Name:        "noProgress",
@@ -366,6 +381,11 @@ func main() {
 						Patterns:    []string{"-p", "--parent"},
 						Description: "Parent id of created directory, can be specified multiple times to give many parents",
 					},
+					cli.StringFlag{
+						Name:        "description",
+						Patterns:    []string{"--description"},
+						Description: "Directory description",
+					},
 				),
 			},
 		},
@@ -397,7 +417,7 @@ func main() {
 						Name:        "domain",
 						Patterns:    []string{"--domain"},
 						Description: "The name of Google Apps domain. Requires 'domain' as type",
-					},					
+					},
 					cli.BoolFlag{
 						Name:        "discoverable",
 						Patterns:    []string{"--discoverable"},

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -115,17 +115,18 @@ func uploadHandler(ctx cli.Context) {
 	args := ctx.Args()
 	checkUploadArgs(args)
 	err := newDrive(args).Upload(drive.UploadArgs{
-		Out:       os.Stdout,
-		Progress:  progressWriter(args.Bool("noProgress")),
-		Path:      args.String("path"),
-		Name:      args.String("name"),
-		Parents:   args.StringSlice("parent"),
-		Mime:      args.String("mime"),
-		Recursive: args.Bool("recursive"),
-		Share:     args.Bool("share"),
-		Delete:    args.Bool("delete"),
-		ChunkSize: args.Int64("chunksize"),
-		Timeout:   durationInSeconds(args.Int64("timeout")),
+		Out:         os.Stdout,
+		Progress:    progressWriter(args.Bool("noProgress")),
+		Path:        args.String("path"),
+		Name:        args.String("name"),
+		Description: args.String("description"),
+		Parents:     args.StringSlice("parent"),
+		Mime:        args.String("mime"),
+		Recursive:   args.Bool("recursive"),
+		Share:       args.Bool("share"),
+		Delete:      args.Bool("delete"),
+		ChunkSize:   args.Int64("chunksize"),
+		Timeout:     durationInSeconds(args.Int64("timeout")),
 	})
 	checkErr(err)
 }
@@ -133,15 +134,16 @@ func uploadHandler(ctx cli.Context) {
 func uploadStdinHandler(ctx cli.Context) {
 	args := ctx.Args()
 	err := newDrive(args).UploadStream(drive.UploadStreamArgs{
-		Out:       os.Stdout,
-		In:        os.Stdin,
-		Name:      args.String("name"),
-		Parents:   args.StringSlice("parent"),
-		Mime:      args.String("mime"),
-		Share:     args.Bool("share"),
-		ChunkSize: args.Int64("chunksize"),
-		Timeout:   durationInSeconds(args.Int64("timeout")),
-		Progress:  progressWriter(args.Bool("noProgress")),
+		Out:         os.Stdout,
+		In:          os.Stdin,
+		Name:        args.String("name"),
+		Description: args.String("description"),
+		Parents:     args.StringSlice("parent"),
+		Mime:        args.String("mime"),
+		Share:       args.Bool("share"),
+		ChunkSize:   args.Int64("chunksize"),
+		Timeout:     durationInSeconds(args.Int64("timeout")),
+		Progress:    progressWriter(args.Bool("noProgress")),
 	})
 	checkErr(err)
 }
@@ -167,15 +169,16 @@ func uploadSyncHandler(ctx cli.Context) {
 func updateHandler(ctx cli.Context) {
 	args := ctx.Args()
 	err := newDrive(args).Update(drive.UpdateArgs{
-		Out:       os.Stdout,
-		Id:        args.String("fileId"),
-		Path:      args.String("path"),
-		Name:      args.String("name"),
-		Parents:   args.StringSlice("parent"),
-		Mime:      args.String("mime"),
-		Progress:  progressWriter(args.Bool("noProgress")),
-		ChunkSize: args.Int64("chunksize"),
-		Timeout:   durationInSeconds(args.Int64("timeout")),
+		Out:         os.Stdout,
+		Id:          args.String("fileId"),
+		Path:        args.String("path"),
+		Name:        args.String("name"),
+		Description: args.String("description"),
+		Parents:     args.StringSlice("parent"),
+		Mime:        args.String("mime"),
+		Progress:    progressWriter(args.Bool("noProgress")),
+		ChunkSize:   args.Int64("chunksize"),
+		Timeout:     durationInSeconds(args.Int64("timeout")),
 	})
 	checkErr(err)
 }
@@ -229,9 +232,10 @@ func listRevisionsHandler(ctx cli.Context) {
 func mkdirHandler(ctx cli.Context) {
 	args := ctx.Args()
 	err := newDrive(args).Mkdir(drive.MkdirArgs{
-		Out:     os.Stdout,
-		Name:    args.String("name"),
-		Parents: args.StringSlice("parent"),
+		Out:         os.Stdout,
+		Name:        args.String("name"),
+		Description: args.String("description"),
+		Parents:     args.StringSlice("parent"),
 	})
 	checkErr(err)
 }


### PR DESCRIPTION
Added a new `--description` parameter to `upload`/`update`/`mkdir` to set the file/directory description.

Changes are minimal but `go fmt` reformatted a number of structs in the process.