### PR TITLE
auth/file_source: don't try to read non-existent files

### DIFF
--- a/auth/file_source.go
+++ b/auth/file_source.go
@@ -47,7 +47,7 @@ func ReadFile(path string) ([]byte, bool, error) {
 func ReadToken(path string) (*oauth2.Token, bool, error) {
 
 	content, exists, err := ReadFile(path)
-	if err != nil {
+	if err != nil || exists == false {
 		return nil, exists, err
 	}
 


### PR DESCRIPTION
Commit b33b3e96e introduced a bug where we try to read a token file even if
it doesn't exist, causing unauthenticated run (e.g.  `gdrive about`) to fail
with the error

    Failed getting oauth client: Failed to read token: unexpected end of JSON input

Closes #257.