### PR TITLE
Fix about output for unlimited drive accounts

### DIFF
--- a/drive/about.go
+++ b/drive/about.go
@@ -22,8 +22,12 @@ func (self *Drive) About(args AboutArgs) (err error) {
 
 	fmt.Fprintf(args.Out, "User: %s, %s\n", user.DisplayName, user.EmailAddress)
 	fmt.Fprintf(args.Out, "Used: %s\n", formatSize(quota.Usage, args.SizeInBytes))
-	fmt.Fprintf(args.Out, "Free: %s\n", formatSize(quota.Limit-quota.Usage, args.SizeInBytes))
-	fmt.Fprintf(args.Out, "Total: %s\n", formatSize(quota.Limit, args.SizeInBytes))
+	if quota.Limit > 0 {
+		fmt.Fprintf(args.Out, "Free: %s\n", formatSize(quota.Limit-quota.Usage, args.SizeInBytes))
+		fmt.Fprintf(args.Out, "Total: %s\n", formatSize(quota.Limit, args.SizeInBytes))
+	} else {
+		fmt.Println("Total: Unlimited")
+	}
 	fmt.Fprintf(args.Out, "Max upload size: %s\n", formatSize(about.MaxUploadSize, args.SizeInBytes))
 	return
 }


### PR DESCRIPTION
G Suite Business Accounts have unlimited space, so their limit is returned as 0 leading to a negative number in the about outputs "Free:" row.

This fixes issue #139. 