### PR TITLE
Support updating permissions for shares and change of ownership

### DIFF
--- a/drive/share.go
+++ b/drive/share.go
@@ -52,6 +52,28 @@ func (self *Drive) RevokePermission(args RevokePermissionArgs) error {
 	return nil
 }
 
+type UpdatePermissionArgs struct {
+	Out          io.Writer
+	FileId       string
+	PermissionId string
+	Role         string
+}
+
+func (self *Drive) UpdatePermission(args UpdatePermissionArgs) error {
+    permission := &drive.Permission{
+		Role:               args.Role,
+	}
+
+	_, err := self.service.Permissions.Update(args.FileId, args.PermissionId, permission).Do()
+	if err != nil {
+		fmt.Errorf("Failed to update permission: %s", err)
+		return err
+	}
+
+	fmt.Fprintf(args.Out, "Permission updated\n")
+	return nil
+}
+
 type ListPermissionsArgs struct {
 	Out    io.Writer
 	FileId string

--- a/drive/share.go
+++ b/drive/share.go
@@ -26,7 +26,14 @@ func (self *Drive) Share(args ShareArgs) error {
 		Domain:             args.Domain,
 	}
 
-	_, err := self.service.Permissions.Create(args.FileId, permission).Do()
+    call := self.service.Permissions.Create(args.FileId, permission)
+
+    if permission.Role == "owner" {
+        call.TransferOwnership(true);
+    }
+
+    _, err := call.Do()
+
 	if err != nil {
 		return fmt.Errorf("Failed to share file: %s", err)
 	}
@@ -64,7 +71,14 @@ func (self *Drive) UpdatePermission(args UpdatePermissionArgs) error {
 		Role:               args.Role,
 	}
 
-	_, err := self.service.Permissions.Update(args.FileId, args.PermissionId, permission).Do()
+	call := self.service.Permissions.Update(args.FileId, args.PermissionId, permission)
+
+    if permission.Role == "owner" {
+        call.TransferOwnership(true);
+    }
+
+    _, err := call.Do()
+
 	if err != nil {
 		fmt.Errorf("Failed to update permission: %s", err)
 		return err

--- a/gdrive.go
+++ b/gdrive.go
@@ -446,6 +446,14 @@ func main() {
 				cli.NewFlagGroup("global", globalFlags...),
 			},
 		},
+        &cli.Handler{
+			Pattern:     "[global] share update <fileId> <permissionId> <role>",
+			Description: "Update permission",
+			Callback:    shareUpdateHandler,
+			FlagGroups: cli.FlagGroups{
+				cli.NewFlagGroup("global", globalFlags...),
+			},
+		},
 		&cli.Handler{
 			Pattern:     "[global] share revoke <fileId> <permissionId>",
 			Description: "Revoke permission",

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -273,6 +273,17 @@ func shareRevokeHandler(ctx cli.Context) {
 	checkErr(err)
 }
 
+func shareUpdateHandler(ctx cli.Context) {
+	args := ctx.Args()
+	err := newDrive(args).UpdatePermission(drive.UpdatePermissionArgs{
+		Out:          os.Stdout,
+		FileId:       args.String("fileId"),
+		PermissionId: args.String("permissionId"),
+		Role: args.String("role"),
+	})
+	checkErr(err)
+}
+
 func deleteHandler(ctx cli.Context) {
 	args := ctx.Args()
 	err := newDrive(args).Delete(drive.DeleteArgs{


### PR DESCRIPTION
This patchset adds support for updating the permissions of shares, not only revoking them. Also, for setting the owner of a file, at share creation or update time.