### PR TITLE
Support --no-header in all list functions and print lists with separators other than tab

### DIFF
--- a/drive/list.go
+++ b/drive/list.go
@@ -16,6 +16,7 @@ type ListFilesArgs struct {
 	Query       string
 	SortOrder   string
 	SkipHeader  bool
+	Separator   string
 	SizeInBytes bool
 	AbsPath     bool
 }
@@ -49,6 +50,7 @@ func (self *Drive) List(args ListFilesArgs) (err error) {
 		Files:       files,
 		NameWidth:   int(args.NameWidth),
 		SkipHeader:  args.SkipHeader,
+		Separator :  args.Separator,
 		SizeInBytes: args.SizeInBytes,
 	})
 
@@ -102,6 +104,7 @@ type PrintFileListArgs struct {
 	Files       []*drive.File
 	NameWidth   int
 	SkipHeader  bool
+	Separator   string
 	SizeInBytes bool
 }
 
@@ -110,16 +113,17 @@ func PrintFileList(args PrintFileListArgs) {
 	w.Init(args.Out, 0, 0, 3, ' ', 0)
 
 	if !args.SkipHeader {
-		fmt.Fprintln(w, "Id\tName\tType\tSize\tCreated")
+		fmt.Fprintf(w, "Id%[1]sName%[1]sType%[1]sSize%[1]sCreated\n", args.Separator)
 	}
 
 	for _, f := range args.Files {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%[1]s%[6]s%[2]s%[6]s%[3]s%[6]s%[4]s%[6]s%[5]s\n",
 			f.Id,
 			truncateString(f.Name, args.NameWidth),
 			filetype(f),
 			formatSize(f.Size, args.SizeInBytes),
 			formatDatetime(f.CreatedTime),
+			args.Separator,
 		)
 	}
 

--- a/drive/share.go
+++ b/drive/share.go
@@ -90,6 +90,8 @@ func (self *Drive) UpdatePermission(args UpdatePermissionArgs) error {
 
 type ListPermissionsArgs struct {
 	Out    io.Writer
+	SkipHeader  bool
+	Separator   string
 	FileId string
 }
 
@@ -102,6 +104,8 @@ func (self *Drive) ListPermissions(args ListPermissionsArgs) error {
 
 	printPermissions(printPermissionsArgs{
 		out:         args.Out,
+		separator:   args.Separator,
+		skipHeader:  args.SkipHeader,
 		permissions: permList.Permissions,
 	})
 	return nil
@@ -123,6 +127,9 @@ func (self *Drive) shareAnyoneReader(fileId string) error {
 
 type printPermissionsArgs struct {
 	out         io.Writer
+	skipHeader  bool
+	separator   string
+
 	permissions []*drive.Permission
 }
 
@@ -130,16 +137,19 @@ func printPermissions(args printPermissionsArgs) {
 	w := new(tabwriter.Writer)
 	w.Init(args.out, 0, 0, 3, ' ', 0)
 
-	fmt.Fprintln(w, "Id\tType\tRole\tEmail\tDomain\tDiscoverable")
+	if !args.skipHeader {
+		fmt.Fprintf(w, "Id%[1]sType%[1]sRole%[1]sEmail%[1]sDomain%[1]sDiscoverable\n", args.separator)
+	}
 
 	for _, p := range args.permissions {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%[1]s%[7]s%[2]s%[7]s%[3]s%[7]s%[4]s%[7]s%[5]s%[7]s%[6]s\n",
 			p.Id,
 			p.Type,
 			p.Role,
 			p.EmailAddress,
 			p.Domain,
 			formatBool(p.AllowFileDiscovery),
+			args.separator,
 		)
 	}
 

--- a/drive/share.go
+++ b/drive/share.go
@@ -52,6 +52,28 @@ func (self *Drive) RevokePermission(args RevokePermissionArgs) error {
 	return nil
 }
 
+type UpdatePermissionArgs struct {
+	Out          io.Writer
+	FileId       string
+	PermissionId string
+	Role         string
+}
+
+func (self *Drive) UpdatePermission(args UpdatePermissionArgs) error {
+    permission := &drive.Permission{
+		Role:               args.Role,
+	}
+
+	_, err := self.service.Permissions.Update(args.FileId, args.PermissionId, permission).Do()
+	if err != nil {
+		fmt.Errorf("Failed to update permission: %s", err)
+		return err
+	}
+
+	fmt.Fprintf(args.Out, "Permission updated\n")
+	return nil
+}
+
 type ListPermissionsArgs struct {
 	Out    io.Writer
 	FileId string

--- a/drive/share.go
+++ b/drive/share.go
@@ -26,7 +26,14 @@ func (self *Drive) Share(args ShareArgs) error {
 		Domain:             args.Domain,
 	}
 
-	_, err := self.service.Permissions.Create(args.FileId, permission).Do()
+    call := self.service.Permissions.Create(args.FileId, permission)
+
+    if permission.Role == "owner" {
+        call.TransferOwnership(true);
+    }
+
+    _, err := call.Do()
+
 	if err != nil {
 		return fmt.Errorf("Failed to share file: %s", err)
 	}
@@ -64,7 +71,14 @@ func (self *Drive) UpdatePermission(args UpdatePermissionArgs) error {
 		Role:               args.Role,
 	}
 
-	_, err := self.service.Permissions.Update(args.FileId, args.PermissionId, permission).Do()
+	call := self.service.Permissions.Update(args.FileId, args.PermissionId, permission)
+
+    if permission.Role == "owner" {
+        call.TransferOwnership(true);
+    }
+
+    _, err := call.Do()
+
 	if err != nil {
 		fmt.Errorf("Failed to update permission: %s", err)
 		return err

--- a/gdrive.go
+++ b/gdrive.go
@@ -19,6 +19,7 @@ const DefaultTimeout = 5 * 60
 const DefaultQuery = "trashed = false and 'me' in owners"
 const DefaultShareRole = "reader"
 const DefaultShareType = "anyone"
+const DefaultSeparator = "\t"
 
 var DefaultConfigDir = GetDefaultConfigDir()
 
@@ -44,6 +45,18 @@ func main() {
 			Name:        "serviceAccount",
 			Patterns:    []string{"--service-account"},
 			Description: "Oauth service account filename, used for server to server communication without user interaction (filename path is relative to config dir)",
+		},
+		cli.BoolFlag{
+			Name:        "skipHeader",
+			Patterns:    []string{"--no-header"},
+			Description: "Dont print the header",
+			OmitValue:   true,
+		},
+		cli.StringFlag{
+		Name:        "separator",
+		Patterns:    []string{"--separator"},
+		Description: "Print list entries separated by provided character",
+			DefaultValue: DefaultSeparator,
 		},
 	}
 
@@ -82,12 +95,6 @@ func main() {
 						Name:        "absPath",
 						Patterns:    []string{"--absolute"},
 						Description: "Show absolute path to file (will only show path from first parent)",
-						OmitValue:   true,
-					},
-					cli.BoolFlag{
-						Name:        "skipHeader",
-						Patterns:    []string{"--no-header"},
-						Description: "Dont print the header",
 						OmitValue:   true,
 					},
 					cli.BoolFlag{
@@ -484,14 +491,6 @@ func main() {
 			Callback:    listSyncHandler,
 			FlagGroups: cli.FlagGroups{
 				cli.NewFlagGroup("global", globalFlags...),
-				cli.NewFlagGroup("options",
-					cli.BoolFlag{
-						Name:        "skipHeader",
-						Patterns:    []string{"--no-header"},
-						Description: "Dont print the header",
-						OmitValue:   true,
-					},
-				),
 			},
 		},
 		&cli.Handler{
@@ -511,12 +510,6 @@ func main() {
 						Patterns:     []string{"--path-width"},
 						Description:  fmt.Sprintf("Width of path column, default: %d, minimum: 9, use 0 for full width", DefaultPathWidth),
 						DefaultValue: DefaultPathWidth,
-					},
-					cli.BoolFlag{
-						Name:        "skipHeader",
-						Patterns:    []string{"--no-header"},
-						Description: "Dont print the header",
-						OmitValue:   true,
 					},
 					cli.BoolFlag{
 						Name:        "sizeInBytes",
@@ -668,12 +661,6 @@ func main() {
 						Description:  fmt.Sprintf("Width of name column, default: %d, minimum: 9, use 0 for full width", DefaultNameWidth),
 						DefaultValue: DefaultNameWidth,
 					},
-					cli.BoolFlag{
-						Name:        "skipHeader",
-						Patterns:    []string{"--no-header"},
-						Description: "Dont print the header",
-						OmitValue:   true,
-					},
 				),
 			},
 		},
@@ -689,12 +676,6 @@ func main() {
 						Patterns:     []string{"--name-width"},
 						Description:  fmt.Sprintf("Width of name column, default: %d, minimum: 9, use 0 for full width", DefaultNameWidth),
 						DefaultValue: DefaultNameWidth,
-					},
-					cli.BoolFlag{
-						Name:        "skipHeader",
-						Patterns:    []string{"--no-header"},
-						Description: "Dont print the header",
-						OmitValue:   true,
 					},
 					cli.BoolFlag{
 						Name:        "sizeInBytes",

--- a/gdrive.go
+++ b/gdrive.go
@@ -446,6 +446,14 @@ func main() {
 				cli.NewFlagGroup("global", globalFlags...),
 			},
 		},
+        &cli.Handler{
+			Pattern:     "[global] share update <fileId> <permissionId> <role>",
+			Description: "Update permission",
+			Callback:    shareUpdateHandler,
+			FlagGroups: cli.FlagGroups{
+				cli.NewFlagGroup("global", globalFlags...),
+			},
+		},
 		&cli.Handler{
 			Pattern:     "[global] share revoke <fileId> <permissionId>",
 			Description: "Revoke permission",

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -273,6 +273,17 @@ func shareRevokeHandler(ctx cli.Context) {
 	checkErr(err)
 }
 
+func shareUpdateHandler(ctx cli.Context) {
+	args := ctx.Args()
+	err := newDrive(args).UpdatePermission(drive.UpdatePermissionArgs{
+		Out:          os.Stdout,
+		FileId:       args.String("fileId"),
+		PermissionId: args.String("permissionId"),
+		Role: args.String("role"),
+	})
+	checkErr(err)
+}
+
 func deleteHandler(ctx cli.Context) {
 	args := ctx.Args()
 	err := newDrive(args).Delete(drive.DeleteArgs{

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -28,6 +28,7 @@ func listHandler(ctx cli.Context) {
 		Query:       args.String("query"),
 		SortOrder:   args.String("sortOrder"),
 		SkipHeader:  args.Bool("skipHeader"),
+		Separator :  args.String("separator"),
 		SizeInBytes: args.Bool("sizeInBytes"),
 		AbsPath:     args.Bool("absPath"),
 	})
@@ -258,6 +259,8 @@ func shareListHandler(ctx cli.Context) {
 	args := ctx.Args()
 	err := newDrive(args).ListPermissions(drive.ListPermissionsArgs{
 		Out:    os.Stdout,
+		SkipHeader: args.Bool("skipHeader"),
+		Separator: args.String("separator"),
 		FileId: args.String("fileId"),
 	})
 	checkErr(err)


### PR DESCRIPTION
This patch adds support for the --no-header option to all list functions, and for printing lists with separators other than tab.