### PR TITLE
Possibility to disable notification when sharing to user or group

### DIFF
--- a/gdrive.go
+++ b/gdrive.go
@@ -435,6 +435,12 @@ func main() {
 						Description: "Delete all sharing permissions (owner roles will be skipped)",
 						OmitValue:   true,
 					},
+					cli.BoolFlag{
+						Name:        "disableNotification",
+						Patterns:    []string{"--no-notification"},
+						Description: "Disable notification e-mail when sharing to user or group. Cannot be disabled for ownership transfer.",
+						OmitValue:   true,
+					},
 				),
 			},
 		},

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -250,6 +250,7 @@ func shareHandler(ctx cli.Context) {
 		Email:        args.String("email"),
 		Domain:       args.String("domain"),
 		Discoverable: args.Bool("discoverable"),
+		DisableNotification: args.Bool("disableNotification"),
 	})
 	checkErr(err)
 }


### PR DESCRIPTION
Added the parameter --no-notification to the action "share" to not send
notification e-mails to users or groups. Not allowed for other requests.
It must not be disabled for ownership transfers.