### PR TITLE
Permission notification message customization

### DIFF
--- a/drive/share.go
+++ b/drive/share.go
@@ -15,6 +15,7 @@ type ShareArgs struct {
 	Email        string
 	Domain       string
 	Discoverable bool
+	NotificationMessage string
 }
 
 func (self *Drive) Share(args ShareArgs) error {
@@ -26,7 +27,14 @@ func (self *Drive) Share(args ShareArgs) error {
 		Domain:             args.Domain,
 	}
 
-	_, err := self.service.Permissions.Create(args.FileId, permission).Do()
+	call := self.service.Permissions.Create(args.FileId, permission)
+
+	if args.NotificationMessage != "" {
+		call = call.EmailMessage(args.NotificationMessage);
+	}
+
+	_, err := call.Do()
+
 	if err != nil {
 		return fmt.Errorf("Failed to share file: %s", err)
 	}

--- a/gdrive.go
+++ b/gdrive.go
@@ -435,6 +435,11 @@ func main() {
 						Description: "Delete all sharing permissions (owner roles will be skipped)",
 						OmitValue:   true,
 					},
+					cli.StringFlag{
+						Name:        "notificationMessage",
+						Patterns:    []string{"--notification-message"},
+						Description: "A custom message to include in the notification email.",
+					},
 				),
 			},
 		},

--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -250,6 +250,7 @@ func shareHandler(ctx cli.Context) {
 		Email:        args.String("email"),
 		Domain:       args.String("domain"),
 		Discoverable: args.Bool("discoverable"),
+		NotificationMessage:	args.String("notificationMessage"),
 	})
 	checkErr(err)
 }


### PR DESCRIPTION
Added the parameter --notification-message to the action "share" to send
customized message to grantees.