### PR TITLE
Disable cgo for release builds.

### DIFF
--- a/_release/build-all.sh
+++ b/_release/build-all.sh
@@ -29,6 +29,7 @@ for PLATFORM in $PLATFORMS; do
 
     export GOOS=$GOOS
     export GOARCH=$GOARCH
+    export CGO_ENABLED=0
 
     echo "Building $BIN_NAME"
     go build -ldflags '-w -s' -o ${BIN_PATH}/${BIN_NAME}


### PR DESCRIPTION
This forces all built binaries to be statically linked.

Fixes #579, #580