### PR TITLE
Update go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You will be prompted for a new verification code if the folder does not exist.
 
 ## Compile from source
 ```bash
-go get github.com/prasmussen/gdrive
+ go install github.com/prasmussen/gdrive@latest
 ```
 The gdrive binary should now be available at `$GOPATH/bin/gdrive`
 


### PR DESCRIPTION
Using the previous command I get the error:

> go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
ubuntu@gpu:~$ go install github.com/prasmussen/g